### PR TITLE
ignore tests during scan

### DIFF
--- a/horus/__init__.py
+++ b/horus/__init__.py
@@ -68,4 +68,4 @@ def includeme(config):
         if not config.registry.queryUtility(form):
             config.registry.registerUtility(SubmitForm, form)
     config.include('horus.routes')
-    config.scan()
+    config.scan(ignore=str('horus.tests'))


### PR DESCRIPTION
There's no reason to scan the tests package during configuration. As a bonus, avoiding so means webtest is not a runtime dependency, but only needed for testing.

The `str()` call is needed because horus.**init**.py uses unicode literals.
