### PR TITLE
Don't register a static view named "static".

### DIFF
--- a/horus/routes.py
+++ b/horus/routes.py
@@ -29,6 +29,5 @@ def includeme(config):
                      factory=UserFactory,
                      traverse="/{user_id}")
 
-    config.add_static_view('static', 'static', cache_max_age=3600)
-
-
+    config.add_static_view(name='horus-static', path='horus:static',
+        cache_max_age=3600)


### PR DESCRIPTION
I am integrating horus into an existing app and...
Guess what is the name of the static view? "static".
This creates a ConfigurationConflictError.
Horus should just use another name...
