### PR TITLE
db.flush after creating Activation to generate code

### DIFF
--- a/horus/views/__init__.py
+++ b/horus/views/__init__.py
@@ -299,7 +299,7 @@ class ForgotPasswordController(BaseController):
         activation = self.Activation()
         self.db.add(activation)
         user.activation = activation
-        self.db.flush()
+        self.db.flush() # initialize activation.code
         
         Str = self.Str
 


### PR DESCRIPTION
currently reset_password emails look like this:

Hello, user!

Someone requested resetting your password. If it was you, click here:
http://localhost/reset_password/None

db.flush() should be called in order to generate the activation.code before throwing it in an email.
