### PR TITLE
Fix bug causing crash in create_user view

### DIFF
--- a/horus/views/admin.py
+++ b/horus/views/admin.py
@@ -33,7 +33,7 @@ class AdminController(BaseController):
             else:
                 return dict(
                     form=form,
-                    appstruct=self.request.context.__json__()
+                    appstruct=self.request.context.__json__(self.request)
                 )
         else:
             try:


### PR DESCRIPTION
This change fixes the following error when accessing the route "/admin/users/{id}/edit":

`TypeError: __json__() missing 1 required positional argument: 'request'`
