### PR TITLE
Fix UserGroup __repr__() method (group_name does not exist)

### DIFF
--- a/horus/models.py
+++ b/horus/models.py
@@ -407,7 +407,7 @@ class UserGroupMixin(BaseModel):
         )
 
     def __repr__(self):
-        return '<UserGroup: %s, %s>' % (self.group_name, self.user_id,)
+        return '<UserGroup: %s, %s>' % (self.group_id, self.user_id,)
 
 __all__ = [
     k for k, v in locals().items()

--- a/horus/tests/test_models.py
+++ b/horus/tests/test_models.py
@@ -330,3 +330,13 @@ class TestGroup(UnitTestBase):
         group = Group.get_by_id(request, group2.id)
 
         assert group.name == 'employees'
+
+class TestUserGroup(UnitTestBase):
+
+    def test_init(self):
+        from horus.tests.models import UserGroup
+        user_group = UserGroup(group_id=1, user_id=1)
+
+        assert repr(user_group) == '<UserGroup: 1, 1>'
+        assert user_group.group_id == 1
+        assert user_group.user_id == 1


### PR DESCRIPTION
Just a small bug I ran into while using Horus